### PR TITLE
Bump to version 0.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lunar-express",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "express": "4.x",
     "graphql": "0.x",
     "graphql-tools": "2.x",
-    "lunar-core": "0.x"
+    "lunar-core": "<=1.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lunar-express",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "An express middleware to help provide deterministic responses to graphql queries and mutations.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Updating [lunar-core](https://github.com/ezcater/lunar-core) dependency to include support for v1.0.0.